### PR TITLE
Update SWE descriptions to include design pattern expectations 

### DIFF
--- a/Engineering Job Levels/1 - Associate Software Engineer.md
+++ b/Engineering Job Levels/1 - Associate Software Engineer.md
@@ -7,7 +7,7 @@ The Associate Software Engineer is at the start of their career and has a reason
  * Works proactively with team members on product features and is developing technical expertise
 
 ## Focus & Complexity
- * Focus on learning functional basics, then applying and increasing functional knowledge 
+ * Focus on learning functional basics, then applying and increasing functional knowledge
  * Seeks out mentorship to grow their own experience
  * Receives deliverables in the form of short-term objectives
  * Follows standard processes to deliver technical or professional work and may make recommendations for improvement
@@ -15,12 +15,12 @@ The Associate Software Engineer is at the start of their career and has a reason
 ## Strategic Impact & Decision Making
  * Has a fundamental understanding of the product
  * Decisions are within scope of individual work and may impact team deliverables
- 
+
 ## Competencies
 
 |                  	|                                  	|                                      	|                                                                                                  Associate Software Engineer                                                                                                  	|
 |------------------	|----------------------------------	|--------------------------------------	|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------	|
-| Technical Skills 	| Quality and Testing              	| Writing code                         	| Writes code with testability, readability, edge cases, and errors in mind.                                                                                                                                                    	|
+| Technical Skills 	| Quality and Testing              	| Writing code                         	| Writes code with testability, readability, edge cases, and errors in mind. Can observe existing design patterns and work within their constructs, but may not understand why that pattern was chosen.                                                                                                                                                    	|
 |                  	|                                  	| Testing                              	| Knows the testing pyramid. Writes unit tests, sometimes with help from more senior engineers.                                                                                                                                 	|
 |                  	| Debugging and Observability      	| Debugging                            	| Understands the basics of debugging and the tools used for it. Is able to identify relevant information to assist with root cause analysis.                                                                                   	|
 |                  	|                                  	| Observability                        	| n/a (not applicable at this level)                                                                                                                                                                                            	|

--- a/Engineering Job Levels/2 - Software Engineer.md
+++ b/Engineering Job Levels/2 - Software Engineer.md
@@ -7,7 +7,7 @@ The Software Engineer displays solid understanding of core engineering concepts.
  * Leverage best practices to write and continually improve the code base
  * Able to own small-to-medium features from technical design through completion.
  * Shouldn’t need assistance with common implementation details. May need architecture assistance.
- * Before beginning work, ensures that tasks are appropriately sized for continuous integration and incremental delivery with help from teammates and manager. 
+ * Before beginning work, ensures that tasks are appropriately sized for continuous integration and incremental delivery with help from teammates and manager.
 
 
 ## Focus & Complexity
@@ -16,16 +16,16 @@ The Software Engineer displays solid understanding of core engineering concepts.
 
 
 ## Strategic Impact & Decision Making
- * Understands product area of focus, how it fits into the overall business, and sometimes makes improvement suggestions for it. 
- * Understands their team's domain, and how it contributes to overall business strategy. 
+ * Understands product area of focus, how it fits into the overall business, and sometimes makes improvement suggestions for it.
+ * Understands their team's domain, and how it contributes to overall business strategy.
  * Decisions are within scope of individual work and may impact team deliverables
 
- 
+
 ## Competencies
 
 |                  	|                                  	|                                      	|                                                                                                                                                         Software Engineer                                                                                                                                                         	|
 |------------------	|----------------------------------	|--------------------------------------	|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------	|
-| Technical Skills 	| Quality and Testing              	| Writing code                         	| Consistently writes functions that are easily testable, easily understood by other developers, and accounts for edge cases and errors. Uses docstrings effectively.                                                                                                                                                               	|
+| Technical Skills 	| Quality and Testing              	| Writing code                         	| Consistently writes functions that are easily testable, easily understood by other developers, and accounts for edge cases and errors. Can observe existing design patterns and work within their constructs and understands why those specific patterns are beneficial.                                                                                                                                                              	|
 |                  	|                                  	| Testing                              	| Understands the testing pyramid, writes unit tests in accordance with it, as well as higher level tests with help from more senior engineers. Always tests expected edge cases and errors as well as the happy path.                                                                                                              	|
 |                  	| Debugging and Observability      	| Debugging                            	| Uses a systematic approach to debug issues located within their team's sphere of ownership. Is able to interpret data to build and test proposed solutions to issues identified in root cause analyses.                                                                                                                           	|
 |                  	|                                  	| Observability                        	| Is aware of the organization's monitoring philosophy and the operational data for their team’s domain.                                                                                                                                                                                                                            	|

--- a/Engineering Job Levels/3 - Senior Software Engineer.md
+++ b/Engineering Job Levels/3 - Senior Software Engineer.md
@@ -1,10 +1,10 @@
 # Senior Software Engineer
 
-The Senior Software Engineer is a rock-solid engineer who is a master of at least one domain. They are capable of owning technical design for projects of moderate complexity, and understand the tradeoffs in creating good software in their area. 
+The Senior Software Engineer is a rock-solid engineer who is a master of at least one domain. They are capable of owning technical design for projects of moderate complexity, and understand the tradeoffs in creating good software in their area.
 
 ## Scope & Responsibility
  * Wide architectural knowledge with the ability to design & build
- * Able to own small-to-medium features from technical design through completion; 
+ * Able to own small-to-medium features from technical design through completion;
  * May mentor other team members
  * Engages in cross platform on-call responsibilities
  * Works to build strong relationships with their teammates, manager, as well as their teams' relevant business stakeholders.
@@ -20,12 +20,12 @@ The Senior Software Engineer is a rock-solid engineer who is a master of at leas
  * Thoroughly understands the business model in relation to their current product focus area. Sometimes participates in roadmap feedback with product team. Looks for opportunities to simplify product & technical design.
  * Mentors their teammates in an open, respectful, flexible, empathetic manner. Seeks out mentoring opportunities specifically to create team redundancy and backfill ability.
 
- 
+
 ## Competencies
 
 |                  	|                                  	|                                      	|                                                                                                                                                         Senior Software Engineer                                                                                                                                                         	|
 |------------------	|----------------------------------	|--------------------------------------	|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------	|
-| Technical Skills 	| Quality and Testing              	| Writing code                         	| Consistently writes production-ready code that is easily testable, easily understood by other developers, and accounts for edge cases and errors. Understands when it is appropriate to leave comments, but biases towards self-documenting code.                                                                                        	|
+| Technical Skills 	| Quality and Testing              	| Writing code                         	| Consistently writes production-ready code that is easily testable, easily understood by other developers, and accounts for edge cases and errors. Understands when it is appropriate to leave comments, but biases towards self-documenting code. Observes existing design patterns in code and works to improve their implementation. Has an understanding of common design patterns in their domain and applies them appropriately.                                                                                        	|
 |                  	|                                  	| Testing                              	| Understands the testing pyramid, and writes unit tests as well as higher level tests in accordance with it. Always writes tests to handle expected edge cases and errors gracefully, as well as happy paths.                                                                                                                             	|
 |                  	| Debugging and Observability      	| Debugging                            	| Proficient at using systematic debugging to diagnose issues located within their team's sphere of ownership. Uses systematic debugging to diagnose cross service issues, and is able to draw informed conclusions sometimes with incomplete data.                                                                                        	|
 |                  	|                                  	| Observability                        	| Is aware of the organization's monitoring philosophy. Helps tune and change the monitoring on their team accordingly. Is aware of the operational data for their team’s domain and uses it as a basis for suggesting stability and performance improvements.                                                                             	|

--- a/Engineering Job Levels/4 - Staff Software Engineer.md
+++ b/Engineering Job Levels/4 - Staff Software Engineer.md
@@ -1,9 +1,9 @@
 # Staff Software Engineer
 
-The Staff Software Engineer has strategic impact over some combination of a large team, a very deep technical problem, and/or a long time horizon. The problems that this engineer is solving are often open-ended. They are a leader within their team and among other engineering groups. 
+The Staff Software Engineer has strategic impact over some combination of a large team, a very deep technical problem, and/or a long time horizon. The problems that this engineer is solving are often open-ended. They are a leader within their team and among other engineering groups.
 
 ## Scope & Responsibility
- * Exemplifies best practices within their domain 
+ * Exemplifies best practices within their domain
  * Engages in cross platform on-call responsibilities
  * Sought out by other team members for technical guidance.
 
@@ -21,12 +21,13 @@ The Staff Software Engineer has strategic impact over some combination of a larg
  * Regularly participates in the creation of the team roadmap and ensuing feedback.
  * Simplifies product and technical design through proactive conversations.
 
- 
+
 ## Competencies
 
 |                  	|                                  	|                                      	|                                                                                                                                                                         Staff Software Engineer                                                                                                                                                                         	|
 |------------------	|----------------------------------	|--------------------------------------	|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------	|
-| Technical Skills 	| Quality and Testing              	| Writing code                         	| Consistently writes production-ready code that is easily testable, easily understood by other developers, and accounts for edge cases and errors. Understands when it is appropriate to leave comments, but biases towards self-documenting code.                                                                                                                       	|
+| Technical Skills 	| Quality and Testing              	| Writing code                         	| Consistently writes production-ready code that is easily testable, easily understood by other developers, and accounts for edge cases and errors. Understands when it is appropriate to leave comments, but biases towards self-documenting code. Has a thorough understanding of design patterns in their domain and applies them appropriately. Can discern the many patterns that could apply in a specific application and understands the tradeoffs. Assists other engineers with their knowledge of design patterns.
+                                                                                                                      	|
 |                  	|                                  	| Testing                              	| Understands their team's quality approach, and uses quality metrics to identify gaps. Works with their team to recommend solutions that are in accordance with accepted testing frameworks and the testing pyramid.                                                                                                                                                     	|
 |                  	| Debugging and Observability      	| Debugging                            	| Proficient at using systematic debugging to diagnose all issues within the scope of their domain.                                                                                                                                                                                                                                                                       	|
 |                  	|                                  	| Observability                        	| Drives monitoring work on their team based on the organization's monitoring philosophy. Is aware of the operational data for their team’s domain and uses it as a basis for driving changes to the team's services to achieve stability and performance improvements.                                                                                                   	|

--- a/Engineering Job Levels/5 - Principal Software Engineer.md
+++ b/Engineering Job Levels/5 - Principal Software Engineer.md
@@ -1,27 +1,27 @@
 # Principal Software Engineer
 
-The Principal Software Engineer collaborates with engineers and other stakeholders to define the functional and non-functional requirements of new solutions, with an emphasis on solutions which require coordination between multiple teams/services. 
+The Principal Software Engineer collaborates with engineers and other stakeholders to define the functional and non-functional requirements of new solutions, with an emphasis on solutions which require coordination between multiple teams/services.
 
 ## Scope & Responsibility
  * Interprets requirements from Product, CX, and from their own independent analysis of application usage and translates these requirements into actionable feature requests
  * Successfully manages cross-team commitments, their progress, and roadmap to delivery.
- * Anticipates and communicates blockers, delays, and cost ballooning across teams, before they require escalation. Ensures expectations across teams and stakeholders are clarified between all parties involved. 
+ * Anticipates and communicates blockers, delays, and cost ballooning across teams, before they require escalation. Ensures expectations across teams and stakeholders are clarified between all parties involved.
 
 
 ## Focus & Complexity
  * Where Staff and Senior System Engineers are focused on incremental improvements within their domains of expertise, the Software Architect is focused on identifying and executing the projects which have the potential to substantially improve a material facet of the business (i.e., across multiple teams or LOBs).
  * Understands how the entire architecture works and how changes made in one area affect another area.
- * Mentors across teams in an open, respectful, flexible, empathetic manner. Fosters a culture of mentoring across teams by seeking out mentoring opportunities for themselves and others, and supports others in their growth as mentors. 
+ * Mentors across teams in an open, respectful, flexible, empathetic manner. Fosters a culture of mentoring across teams by seeking out mentoring opportunities for themselves and others, and supports others in their growth as mentors.
 
 
 ## Strategic Impact & Decision Making
  * Often helps refine roadmaps across teams based on technical strategy & constraints. Helps to define & create new product abilities by changing technical strategy or constraints.
- 
+
 ## Competencies
 
 |                  	|                                  	|                                      	|                                                                                                                                                                                                                     Principal Software Engineer                                                                                                                                                                                                                    	|
 |------------------	|----------------------------------	|--------------------------------------	|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------	|
-| Technical Skills 	| Quality and Testing              	| Writing code                         	| Consistently writes production-ready code that is easily testable, easily understood by other developers, and accounts for edge cases and errors. Understands when it is appropriate to leave comments, but biases towards self-documenting code.                                                                                                                                                                                                         	|
+| Technical Skills 	| Quality and Testing              	| Writing code                         	| Consistently writes production-ready code that is easily testable, easily understood by other developers, and accounts for edge cases and errors. Understands when it is appropriate to leave comments, but biases towards self-documenting code. Has a thorough understanding of design patterns in their domain and applies them appropriately. Can discern the many patterns that could apply in a specific application and understands the tradeoffs. Assists other engineers with their knowledge of design patterns.                                                                                                                                                                                                         	|
 |                  	|                                  	| Testing                              	| Understands the testing approach of several teams, and uses quality metrics to identify gaps. Works with those teams to recommend solutions that are in accordance with accepted testing frameworks and the testing pyramid. Influences organization wide testing strategy.                                                                                                                                                                               	|
 |                  	| Debugging and Observability      	| Debugging                            	| Proficient at using systematic debugging to diagnose all issues within a set of related domains.                                                                                                                                                                                                                                                                                                                                                          	|
 |                  	|                                  	| Observability                        	| Fosters a culture of observability across several teams and helps them use operational data to improve stability and performance of their domains.                                                                                                                                                                                                                                                                                                        	|


### PR DESCRIPTION
## Description
This PR attempts to make implicit expectations about software design pattern usage explicit in our job descriptions. I added the following expectations:

- Associate: Can observe existing design patterns and work within their constructs, but may not understand why that pattern was chosen.
- Engineer: Can observe existing design patterns and work within their constructs and understands why those specific patterns are beneficial.
- Senior Engineer: Observes existing design patterns in code and works to improve their implementation. Has an understanding of common design patterns in their domain and applies them appropriately.
- Staff Engineer: Has a thorough understanding of design patterns in their domain and applies them appropriately. Can discern the many patterns that could apply in a specific application and understands the tradeoffs. Assists other engineers with their knowledge of design patterns.
- Principal: No change from Staff

Feedback welcome!